### PR TITLE
Add Bio-image Analysis Notebooks link & update sampling theorem credit

### DIFF
--- a/chapters/1-concepts/1-images_and_pixels/python.md
+++ b/chapters/1-concepts/1-images_and_pixels/python.md
@@ -42,6 +42,8 @@ Before continuing, you should [make the notebook interactive](sec-live-notebooks
 
 :::{admonition} Python overview
 If you want a quick introduction to Python, check out the [Python Primer](../../appendices/python/python.md) section.
+
+For lots more, see Robert Haase's [Bio-image Analysis Notebooks](https://haesleinhuepf.github.io/BioImageAnalysisNotebooks/).
 :::
 
 
@@ -57,7 +59,7 @@ Read and display an image in Python.
 """
 
 # In Python, we need to import things before we can use them
-# (And, often, google to find out what we ought to be importing, 
+# (And, often, google to find out what we ought to be importing,
 # then copy & paste the same import statements a lot)
 import matplotlib.pyplot as plt
 from imageio import imread
@@ -94,7 +96,7 @@ help(plt.imshow)
 
 This can sometimes reveal an overwhelming amount of information, and it can take a bit of time to figure out how to identify the key bits.
 
-The important plotting options for our purposes are 
+The important plotting options for our purposes are
 * `cmap` to change the colormap (LUT)
 * `vmin` to change the pixel value corresponding to the first color in the colormap
 * `vmax` to change the pixel value corresponding to the last color in the colormap
@@ -193,17 +195,17 @@ def my_imshow(im, title=None, cmap='gray'):
     Call imshow and turn the axis off, optionally setting a title and colormap.
     The default colormap is 'gray', and there is no default title.
     """
-    
+
     # Show image & turn off axis
     plt.imshow(im, cmap=cmap)
     plt.axis(False)
-    
+
     # Show a title if we have one
     if title is not None:
         plt.title(title)
-        
+
     plt.show()
-    
+
 # Now I just need to call my function rather than customize every plot
 my_imshow(im, title='Here is my new title')
 my_imshow(im, title='Now I have inverted the colormap', cmap='gray_r')

--- a/chapters/2-processing/7-multidimensional_processing/imagej.md
+++ b/chapters/2-processing/7-multidimensional_processing/imagej.md
@@ -297,7 +297,7 @@ Its settings (analogous to {menuselection}`Set Measurements...`) are under {menu
 In addition to various measurements, it provides labelled images as output, either of the entire objects or only their central pixels – optionally with labels, or expanded to be more visible.
 
 [^fn_3]: See See S Bolte and F P Cordelières.
-“A guided tour into subcellular colocalization analysis in light microscopy.” In: Journal of Microscopy 224.Pt 3 (Dec. 2006), pp. 213–32.
+“A guided tour into subcellular colocalization analysis in light microscopy.” Journal of Microscopy 224.Pt 3 (Dec. 2006), pp. 213–32.
 url: https://pubmed.ncbi.nlm.nih.gov/17210054/
 
 :::{admonition} Find Connected Regions

--- a/chapters/3-fluorescence/3-formation_noise/formation_noise.md
+++ b/chapters/3-fluorescence/3-formation_noise/formation_noise.md
@@ -1043,7 +1043,7 @@ Small pixels are needed to see detail, but also reduce the number of photons per
 However, {ref}`chap_formation_spatial` has already argued that ultimately it's not pixel size, but rather the PSF that limits spatial resolution -- which suggests that there is a minimum pixel size below which nothing is gained, and the only result is that more noise is added.
 
 This size can be determined based upon knowledge of the PSF and the **Nyquist-Shannon sampling theorem** ({numref}`fig-nyquist_shannon`).
-Images acquired with this pixel size are said to be **Nyquist sampled**.
+Images acquired with this pixel size are said to be **Nyquist sampled** (although see Alvy Ray Smith's epic *A Biography of the Pixel* for the case why credit for the sampling theorem really belongs to **Vladimir Kotelnikov**).
 
 The easiest way I know to determine the corresponding pixel size for a given experiment is to use the online calculator provided by *Scientific Volume Imaging* at https://svi.nl/NyquistCalculator.
 You may need larger pixels to reduce noise or see a wider field of view, but you do not get anything extra by using smaller pixels.


### PR DESCRIPTION
* Link to @haesleinhuepf's https://github.com/haesleinhuepf/BioImageAnalysisNotebooks (wonderful stuff I didn't know existed before)
* Add Vladimir Kotelnikov to the mention of the sampling theorem (see chapter 2 and p445 of 'A biography of the pixel' by Alvy Ray Smith for more details)