### PR TITLE
Filters Fig.80: use same y axis scaling across row

### DIFF
--- a/chapters/2-processing/4-filters/filters.md
+++ b/chapters/2-processing/4-filters/filters.md
@@ -108,7 +108,7 @@ kernel /= kernel.sum()
 
 # Ensure aligned
 # fig = create_figure(figsize=(8, 8))
-fig, ax = plt.subplots(2, 3, sharex='col', figsize=(8, 5), dpi=200)
+fig, ax = plt.subplots(2, 3, sharex='col', sharey='row', figsize=(8, 5), dpi=200)
 
 # Show images & plots
 show_image(im, title="(A) Original image", pos=231)


### PR DESCRIPTION
This better illustrates the scale of the noise removed by filtering.

Before:
![image](https://user-images.githubusercontent.com/2033938/192548177-1c6ccf5b-d3f3-4827-a35a-5db549795201.png)

After:
![image](https://user-images.githubusercontent.com/2033938/192549116-0008bf40-c065-414b-a6b2-0b67273e27b8.png)

