### PR TITLE
Use index.md as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 
 This book tries explain the main ideas of bioimage analysis in a practical and engaging way.
 
-You're currently looking at the ReadMe - for that actual book, see https://bioimagebook.github.io
+You're currently looking at the ReadMe - for the actual book, see https://bioimagebook.github.io

--- a/README.md
+++ b/README.md
@@ -4,18 +4,6 @@
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC_BY_4.0-blue.svg)](https://creativecommons.org/licenses/by/4.0/)
 [![Twitter](https://img.shields.io/twitter/follow/petebankhead?style=flat)](https://twitter.com/petebankhead)
 
-This book tries explain the main ideas of image analysis in a practical and engaging way.
+This book tries explain the main ideas of bioimage analysis in a practical and engaging way.
 
-It's written primarily for busy biologists who need to analyze images as part of their work -- but I hope others might find it useful as well.
-
-The core content is based on my earlier handbook *Analyzing fluorescence microscopy images with ImageJ* ([PDF](https://www.researchgate.net/publication/260261544_Analyzing_fluorescence_microscopy_images_with_ImageJ), [GitBook](https://petebankhead.gitbooks.io/imagej-intro/)).
-This has been extensively revised, generalized and expanded; the new title reflects the fact that it's no longer entirely focussed on fluorescence images, nor on ImageJ -- although both still play a big role.
-
-The biggest change is that it now exists as an open [Jupyter Book](https://jupyterbook.org).
-This makes the whole thing more maintainable for me, and interactive for anyone who reads it.
-
-It's a work in progress, and probably always will be, but I hope you find it useful.
-
-> You can download the images used in the practical exercises [here](https://github.com/bioimagebook/practical-data/archive/refs/heads/main.zip).
-
-<img src="./images/title_cells.jpg" alt="Title image" width="40%" align="center" />
+You're currently looking at the ReadMe - for that actual book, see https://bioimagebook.github.io

--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,10 @@
 title: "Introduction to Bioimage Analysis"
 author       : "Pete Bankhead"  # The author of the book
-copyright    : "2022"  # Copyright year to be placed in the footer
+copyright    : "2022-2023"  # Copyright year to be placed in the footer
 logo         : 'images/book-logo-smaller.png'
 
 exclude_patterns            : [_build, Thumbs.db, .DS_Store, "**.ipynb_checkpoints", '_unused/**', 'nbs/*']
-only_build_toc_files: true
+only_build_toc_files: false
 
 execute:
   execute_notebooks: "auto"

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,5 +1,5 @@
 format: jb-book
-root: README
+root: index
 parts:
 - caption: Front matter
   chapters:

--- a/index.md
+++ b/index.md
@@ -1,2 +1,21 @@
-```{include} README.md
-```
+# Introduction to Bioimage Analysis
+
+[![Jupyter Book Badge](https://jupyterbook.org/badge.svg)](https://bioimagebook.github.io)
+[![License: CC BY 4.0](https://img.shields.io/badge/License-CC_BY_4.0-blue.svg)](https://creativecommons.org/licenses/by/4.0/)
+[![Twitter](https://img.shields.io/twitter/follow/petebankhead?style=flat)](https://twitter.com/petebankhead)
+
+This book tries explain the main ideas of image analysis in a practical and engaging way.
+
+It's written primarily for busy biologists who need to analyze images as part of their work -- but I hope others might find it useful as well.
+
+The core content is based on my earlier handbook *Analyzing fluorescence microscopy images with ImageJ* ([PDF](https://www.researchgate.net/publication/260261544_Analyzing_fluorescence_microscopy_images_with_ImageJ), [GitBook](https://petebankhead.gitbooks.io/imagej-intro/)).
+This has been extensively revised, generalized and expanded; the new title reflects the fact that it's no longer entirely focussed on fluorescence images, nor on ImageJ -- although both still play a big role.
+
+The biggest change is that it now exists as an open [Jupyter Book](https://jupyterbook.org).
+This makes the whole thing more maintainable for me, and interactive for anyone who reads it.
+
+It's a work in progress, and probably always will be, but I hope you find it useful.
+
+> You can download the images used in the practical exercises [here](https://github.com/bioimagebook/practical-data/archive/refs/heads/main.zip).
+
+<img src="./images/title_cells.jpg" alt="Title image" width="40%" align="center" />

--- a/index.md
+++ b/index.md
@@ -1,0 +1,2 @@
+```{include} README.md
+```


### PR DESCRIPTION
Purpose is to support https://bioimagebook.github.io without redirecting to https://bioimagebook.github.io/README.html (since the latter is often used as the path to the book... since that's what copying & pasting the URL gives)