### PR TITLE
Block translating UI elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+Changelog
+=========
+
+This page summarizes the main changes.
+To see all changes, check out the [commit log](https://github.com/bioimagebook/bioimagebook.github.io/commits/main).
+
+## 15 January 2023
+
+* Add this changelog
+* Make `index.html` the main page, not `README.html`
+  * Please use https://bioimagebook.github.io as the main book link (*not* https://bioimagebook.github.io/README.html)!
+* Add `notranslate` class to button text and menu items
+  * This aims to make Google Translate (and perhaps other translators) give more meaningful output, without mangling user interface elements.
+
+
+## 20 April 2022
+
+* First release!

--- a/_config.yml
+++ b/_config.yml
@@ -3,8 +3,8 @@ author       : "Pete Bankhead"  # The author of the book
 copyright    : "2022-2023"  # Copyright year to be placed in the footer
 logo         : 'images/book-logo-smaller.png'
 
-exclude_patterns            : [_build, Thumbs.db, .DS_Store, "**.ipynb_checkpoints", '_unused/**', 'nbs/*']
-only_build_toc_files: false
+exclude_patterns     : [_build, Thumbs.db, .DS_Store, "**.ipynb_checkpoints", '_unused/**', 'nbs/*']
+only_build_toc_files : false
 
 execute:
   execute_notebooks: "auto"
@@ -28,6 +28,7 @@ parse:
 
 sphinx:
   config:
+    html_baseurl: https://bioimagebook.github.io/
     bibtex_bibfiles:
       - "references.bib"
     html_js_files:
@@ -35,6 +36,10 @@ sphinx:
       - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
     templates_path:
       - _templates
+  extra_extensions:
+    - sphinx_sitemap
+  local_extensions:
+    notranslate_gui: _ext
 
 latex:
   latex_engine: xelatex

--- a/_ext/notranslate_gui.py
+++ b/_ext/notranslate_gui.py
@@ -1,0 +1,43 @@
+"""
+Minimal extension that adds 'notranslate' class to guilabel and menuselection tags.
+
+The point of this is to tell Google Translate (and possibly other translators) not 
+to translate button and menu text.
+
+This should make automatic translations more usable, since they don't impact 
+user interface elements in the software.
+
+Important! This implementation is very simple, and overrides the 'default' guilabel 
+and menuselection handling.
+In particular, it doesn't bother with supporting accelerators (flagged by &).
+"""
+
+from docutils import nodes
+
+_BULLET_CHARACTER = '\N{TRIANGULAR BULLET}'
+
+def guilabel_notranslate(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    node = nodes.inline(rawtext=rawtext, text=text, classes=[name, 'notranslate'])
+    return [node], []
+
+
+def menuselection_notranslate(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    text = text.replace('-->', _BULLET_CHARACTER)
+    node = nodes.inline(rawtext=rawtext, text=text, classes=[name, 'notranslate'])
+    return [node], []
+
+
+def span_notranslate(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    node = nodes.inline(rawtext=rawtext, text=text, classes=['notranslate'])
+    return [node], []
+
+
+def setup(app):
+    app.add_role("guilabel", guilabel_notranslate, override=True)
+    app.add_role("menuselection", menuselection_notranslate, override=True)
+    app.add_role("notranslate", span_notranslate)
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/_toc.yml
+++ b/_toc.yml
@@ -6,6 +6,7 @@ parts:
   - file: chapters/0-preamble/acknowledgements/acknowledgements
   - file: chapters/0-preamble/license
   - file: chapters/0-preamble/disclaimer
+  - file: CHANGELOG.md
 - caption: Before we begin
   chapters:
   - file: chapters/0-preamble/preface/preface

--- a/chapters/1-concepts/1-images_and_pixels/imagej.md
+++ b/chapters/1-concepts/1-images_and_pixels/imagej.md
@@ -186,7 +186,7 @@ The search bar can also be activated using {kbd}`L` and used to find and run com
 :::{admonition} Losing control
 :class:
 
-In most software, shortcut keys often requires pressing {kbd}`Ctrl` (on Windows, Linux) or {kbd}`⌘` (Mac).
+In most software, shortcut keys often require pressing {kbd}`Ctrl` (on Windows, Linux) or {kbd}`⌘` (Mac).
 Therefore the shortcut to search for a command would be {kbd}`Ctrl + L` or {kbd}`⌘ + L`.
 
 This works in ImageJ, but isn't necessary.

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ This book tries explain the main ideas of image analysis in a practical and enga
 
 It's written primarily for busy biologists who need to analyze images as part of their work -- but I hope others might find it useful as well.
 
-The core content is based on my earlier handbook *Analyzing fluorescence microscopy images with ImageJ* ([PDF](https://www.researchgate.net/publication/260261544_Analyzing_fluorescence_microscopy_images_with_ImageJ), [GitBook](https://petebankhead.gitbooks.io/imagej-intro/)).
+The core content is based on my earlier handbook *{notranslate}`Analyzing fluorescence microscopy images with ImageJ`* ([PDF](https://www.researchgate.net/publication/260261544_Analyzing_fluorescence_microscopy_images_with_ImageJ), [GitBook](https://petebankhead.gitbooks.io/imagej-intro/)).
 This has been extensively revised, generalized and expanded; the new title reflects the fact that it's no longer entirely focussed on fluorescence images, nor on ImageJ -- although both still play a big role.
 
 The biggest change is that it now exists as an open [Jupyter Book](https://jupyterbook.org).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.23.2
-myst_nb==0.13.1
+myst_nb==0.13.2
 pandas==1.4.3
 imageio==2.21.1
 scikit_image==0.19.3
@@ -7,3 +7,4 @@ matplotlib==3.5.1
 scipy==1.9.0
 jupyter-book==0.13.1
 jupytext==1.14.1
+sphinx-sitemap==2.4.0


### PR DESCRIPTION
Add 'notranslate' class to `guilabel` and `menuselection`. This aims to make Google Translate (and perhaps other translators) give more meaningful output, without mangling user interface elements.

Note that this currently prevents accelerators being highlighted with `guilabel` and `menuselection` (but I wasn't using this anyway... I think).

Also add sitemap.xml (in case it helps)

And add a changelog to record this