### PR TITLE
Update Python version, image size

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,4 +18,4 @@ It's a work in progress, and probably always will be, but I hope you find it use
 
 > You can download the images used in the practical exercises [here](https://github.com/bioimagebook/practical-data/archive/refs/heads/main.zip).
 
-<img src="./images/title_cells_with_alpha.png" alt="Title image" max-width="70%" align="center" class="dark-light" />
+<img src="./images/title_cells_with_alpha.png" alt="Title image" width="70%" class="dark-light align-center" />

--- a/index.md
+++ b/index.md
@@ -18,4 +18,4 @@ It's a work in progress, and probably always will be, but I hope you find it use
 
 > You can download the images used in the practical exercises [here](https://github.com/bioimagebook/practical-data/archive/refs/heads/main.zip).
 
-<img src="./images/title_cells_with_alpha.png" alt="Title image" width="40%" align="center" class="dark-light" />
+<img src="./images/title_cells_with_alpha.png" alt="Title image" max-width="70%" align="center" class="dark-light" />

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ imageio==2.26.0
 scikit_image==0.20.0
 matplotlib==3.7.1
 scipy==1.10.1
-jupyter-book==0.15.0
+jupyter-book==0.15.1
 jupytext==1.14.5
 sphinx-sitemap==2.5.0

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9
+python-3.10


### PR DESCRIPTION
Hopefully fixes
* https://github.com/bioimagebook/bioimagebook.github.io/issues/20

Python 3.10 required (fortunately, it should now be the default in mybinder).

Also updated image size for index.md.