### PR TITLE
Update license & reuse, fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,20 @@ Changelog
 This page summarizes the main changes.
 To see all changes, check out the [commit log](https://github.com/bioimagebook/bioimagebook.github.io/commits/main).
 
+## 18 November 2023
+* Add copyright note to each page (thanks to @haesleinhuepf)
+  * https://github.com/bioimagebook/bioimagebook.github.io/issues/28
+* Rename & update 'License & Reuse' section for clarity
+* Fix typo (thanks to @PeteHaitch)
+  * https://github.com/bioimagebook/bioimagebook.github.io/pull/27
+
+
 ## 3 June 2023
 
 * Switch to using `conda` and `environment.yml`
 * Update dependencies (and fix the various errors this caused)
 * Introduce aiscsimageio & use imageio.v3
-  * Major update to the Python notebook in the 'Pixel sizes & dimensions' chapter
+  * Major update to the Python notebook in the 'Pixel size & dimensions' chapter
 
 ## 8 March 2023
 

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ exclude_patterns     : [_build, Thumbs.db, .DS_Store, "**.ipynb_checkpoints", '_
 only_build_toc_files : false
 
 execute:
-  execute_notebooks: "auto"
+  execute_notebooks: cache
 
 repository:
   url           : https://github.com/bioimagebook/bioimagebook.github.io # Online location of your book
@@ -25,6 +25,13 @@ parse:
     - dollarmath
     - substitution
     - html_image
+
+html:
+  extra_footer: |
+      <p>
+      All content is licensed under <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC-BY 4.0</a>, except where noted otherwise.
+      See <a href="https://bioimagebook.github.io/chapters/0-preamble/license.html" target="_blank">License & Reuse</a> for details.
+      </p>
 
 sphinx:
   config:

--- a/chapters/0-preamble/license.md
+++ b/chapters/0-preamble/license.md
@@ -1,5 +1,15 @@
-# License
+# License & Reuse
 
-<a rel="license" href="https://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>
+<a rel="license" href="https://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />All original content by the author is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 
-Please check the [acknowledgements](acknowledgements/acknowledgements) for extra information about image sources.
+This includes all text and drawings, unless otherwise noted.
+
+My aim is to make the content easy to reuse.
+Content from others is used sparingly to keep things simple.
+
+The main exception is that I'm not a microscopist, so the original microscopy images are always from others.
+Please check the [acknowledgements](acknowledgements/acknowledgements) for more specific information.
+
+If you want to recreate similar figures using your *own* microscopy images, you can use [the code in the book](sec-live-notebooks) to do that.
+
+And if you find any attribution is missing or incorrect, please [create a PR or open an issue on GitHub](https://github.com/bioimagebook/bioimagebook.github.io) so it can be fixed.

--- a/chapters/1-concepts/4-colors/colors.md
+++ b/chapters/1-concepts/4-colors/colors.md
@@ -452,7 +452,7 @@ Again, no information is lost: we can access the original pixel values, and upda
 
 Just like with a single channel image, we can create an RGB image that allows us to visualize our multichannel image -- using the LUTs to figure out which RGB values are needed to represent the color of each pixel.
 
-Then, againf just like with the single channel image, this is problematic if we don't keep the raw data -- because we can never recover the original values from the RGB representation.
+Then, again just like with the single channel image, this is problematic if we don't keep the raw data -- because we can never recover the original values from the RGB representation.
 
 
 ```{glue:figure} fig_colors_composite_rgb_split


### PR DESCRIPTION
Update License & Reuse for clarity, & include copyright statement on each page as suggested by @haesleinhuepf
* https://github.com/bioimagebook/bioimagebook.github.io/issues/28

Also include typo fix from @PeteHaitch described at https://github.com/bioimagebook/bioimagebook.github.io/pull/27 (thanks!)

Turn on caching, to make builds less painfully slow (at least when testing things locally).